### PR TITLE
fix: wrong key

### DIFF
--- a/tricoloring_stable.py
+++ b/tricoloring_stable.py
@@ -97,7 +97,7 @@ cache = {}
 
 
 def recurse(sumR: int, sumG: int, sumB: int, curAns: str, restArr: list) -> str:
-    key = (sumR, sumG, sumB, "".join(str(i) for i in restArr))
+    key = (sumR, sumG, sumB, ",".join(str(i) for i in restArr))
     if key in cache:
         # print(key, cache[key])
         return cache[key]


### PR DESCRIPTION
- Fix wrong key in case of `[0, 11] ` and `[0, 1, 1]` which will be recognized as same key using the old format